### PR TITLE
Fix ‘command not found’ error

### DIFF
--- a/kernel_build_and_install_for_pi2_pi3.bash
+++ b/kernel_build_and_install_for_pi2_pi3.bash
@@ -41,5 +41,4 @@ make modules_install
 cp arch/arm/boot/dts/*.dtb /boot/
 cp arch/arm/boot/dts/overlays/*.dtb* /boot/overlays/
 cp arch/arm/boot/dts/overlays/README /boot/overlays/
-scripts/mkknlimg arch/arm/boot/zImage /boot/$KERNEL.img
-
+cp arch/arm/boot/zImage /boot/$KERNEL.img


### PR DESCRIPTION
`/usr/src/scripts/mkknlimg` does not exist.
I changed the command to the way of the official page.