### PR TITLE
fatal error: openssl/bio.h: No such file or directory

### DIFF
--- a/kernel_build_and_install_for_pi2_pi3.bash
+++ b/kernel_build_and_install_for_pi2_pi3.bash
@@ -25,7 +25,8 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #SOFTWARE.
 
-apt-get install bc bison flex
+apt-get update
+apt-get install bc bison flex libssl-dev 
 cd /usr/src
 
 git clone --depth=1 https://github.com/raspberrypi/linux || ( cd ./linux && git pull )


### PR DESCRIPTION
## 検証環境
```
uname -a
Linux raspberrypi 4.19.66-v7+ #1253 SMP Thu Aug 15 11:49:46 BST 2019 armv7l GNU/Linux
```
```
lsb_release -a
No LSB modules are available.
Distributor ID:	Raspbian
Description:	Raspbian GNU/Linux 10 (buster)
Release:	10
Codename:	buster
```
## 発生したエラー
```
make -j4 zImage modules dtbs
+ make -j4 zImage modules dtbs
scripts/kconfig/conf  --syncconfig Kconfig
  HOSTCC  scripts/extract-cert
scripts/extract-cert.c:21:10: fatal error: openssl/bio.h: No such file or directory
 #include <openssl/bio.h>
          ^~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [scripts/Makefile.host:90: scripts/extract-cert] Error 1
make: *** [Makefile:1061: scripts] Error 2
make: *** Waiting for unfinished jobs....
```
## 原因
`openssl/bio.h`が存在しないのが原因

## 解決方法
`libssl-dev`をインストール
```
sudo apt install libssl-dev
```